### PR TITLE
fix 検査実施件数の日付ラベルのゼロ埋めを除去

### DIFF
--- a/patients.py
+++ b/patients.py
@@ -433,8 +433,12 @@ def main():
                 month=int(validate_result_date[1]),
                 day=int(validate_result_date[2]),
             )
+            # pythonの日付書式フォーマットだとゼロ埋めとなるので、一度分解して左側のゼロを消して文字列に戻す（力技です）
             inspections_summary_labels.append(
-                inspections_summary_date.strftime("%m/%d")
+                "/".join(
+                    n_s.lstrip("0")
+                    for n_s in inspections_summary_date.strftime("%m/%d").split("/")
+                )
             )
 
             # 件数:検査実施_件数 （医療機関等）の追加


### PR DESCRIPTION
fixed #11 

関連するissue: https://github.com/aktnk/covid19/issues/34

検査実施件数の日付ラベルで左側にゼロが出てしまう問題に対応します。