### PR TITLE
地域名フィルター機能の導入

### DIFF
--- a/bat.sh
+++ b/bat.sh
@@ -3,4 +3,4 @@ curl https://opendata.pref.shizuoka.jp/dataset/8167/resource/46279/220001_shizuo
 curl https://opendata.pref.shizuoka.jp/dataset/8167/resource/45876/220001_shizuoka_covid19_test_number.csv > test_number.csv
 curl https://opendata.pref.shizuoka.jp/dataset/8167/resource/48851/220001_new_shizuoka_covid19_patients.csv > details_of_confirmed_cases.csv
 
-python patients.py patients.csv call_center.csv test_number.csv details_of_confirmed_cases.csv "富士市"
+python patients.py patients.csv call_center.csv test_number.csv details_of_confirmed_cases.csv


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #31 

## 📝 関連する issue / Related Issues
- #32

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
#32 でrevert( #33 )した、地域名フィルター機能追加時のテスト用に設定していた地域名を除外した変更です。

 以下 #32からの引用

- 地域名を元にフィルターする機能を追加しています
- この変更で、「陽性者の属性」のデータを市町名でフィルターできます。
  - 対応を始めたばかりで仕様を決めていないのですが、陽性者属性に書かれている市町名をそのまま利用することで、その市町名のみの属性情報が残るようになっています
  - ほかのデータについてはフィルターしていません（市町の属性が入ってないのでできません）
