### PR TITLE
"検査（検体採取）実施人数"グラフラベルへ西暦追加

### DIFF
--- a/patients.py
+++ b/patients.py
@@ -457,7 +457,7 @@ def main():
             inspections_summary_labels.append(
                 "/".join(
                     n_s.lstrip("0")
-                    for n_s in inspections_summary_date.strftime("%m/%d").split("/")
+                    for n_s in inspections_summary_date.strftime("%Y/%m/%d").split("/")
                 )
             )
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #35 

## 📝 関連する issue / Related Issues
- https://github.com/aktnk/covid19/issues/60
  - https://github.com/hiroyuki-ichikawa/covid19/pull/145

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- "検査（検体採取）実施人数"グラフのラベルに西暦追加をします
- 今までは`4/22` というフォーマットでしたが、`2020/4/27` のような西暦ありの日付フォーマットに切り替えます
  - データの年度が変わったためグラフ側にも西暦考慮が必要になりました

## 📸 スクリーンショット / Screenshots
<!-- 参考画像があれば添付してください -->

![image](https://user-images.githubusercontent.com/23502/105570163-d24c0700-5d8a-11eb-814e-1b76100219be.png)
