### PR TITLE
オープンデータ「検査陽性者の状況」のCSVの項目変更へ対応「自宅療養者」と「入院等調整中」を新設

### DIFF
--- a/patients.py
+++ b/patients.py
@@ -64,7 +64,11 @@ MAIN_SUMMARY_JSON_TEMPLATE = """
                     "value": 0
                 },
                 {
-                    "attr": "入院・療養等調整中",
+                    "attr": "自宅療養",
+                    "value": 0
+                },
+                {
+                    "attr": "入院等調整中",
                     "value": 0
                 },
                 {
@@ -210,9 +214,10 @@ def gen_main_summary_data(details_of_confirmed_cases_filename: str):
     入院: 0
     うち重症: 1
     宿泊療養: 2
-    入院等調整中: 3
-    死亡: 4
-    退院: 5
+    自宅療養: 3
+    入院等調整中: 4
+    死亡: 5
+    退院: 6
 
 
     """
@@ -232,15 +237,17 @@ def gen_main_summary_data(details_of_confirmed_cases_filename: str):
                 + case_count_list["3"]
                 + case_count_list["4"]
                 + case_count_list["5"]
+                + case_count_list["6"]
             ),  # 陽性患者数 = 入院 + 療養 + 調整中 + 死亡 + 退院
             "入院中": case_count_list["0"],
             "軽症・中等症": case_count_list["0"]
             - case_count_list["1"],  # 軽症・中等症 = 入院中 - うち重症
             "重症": case_count_list["1"],
             "宿泊療養": case_count_list["2"],
-            "入院・療養等調整中": case_count_list["3"],
-            "死亡": case_count_list["4"],
-            "退院": case_count_list["5"],
+            "自宅療養": case_count_list["3"],
+            "入院等調整中": case_count_list["4"],
+            "死亡": case_count_list["5"],
+            "退院": case_count_list["6"],
         }
 
 
@@ -526,12 +533,14 @@ def main():
     main_summary_d3[1]["value"] = main_summary_counts["重症"]
     # 宿泊療養
     main_summary_d2[1]["value"] = main_summary_counts["宿泊療養"]
-    # 入院・療養等調整中 / 調査中
-    main_summary_d2[2]["value"] = main_summary_counts["入院・療養等調整中"]
+    # 自宅療養
+    main_summary_d2[2]["value"] = main_summary_counts["自宅療養"]
+    # 入院等調整中
+    main_summary_d2[3]["value"] = main_summary_counts["入院等調整中"]
     # 死亡
-    main_summary_d2[3]["value"] = main_summary_counts["死亡"]
+    main_summary_d2[4]["value"] = main_summary_counts["死亡"]
     # 退院
-    main_summary_d2[4]["value"] = main_summary_counts["退院"]
+    main_summary_d2[5]["value"] = main_summary_counts["退院"]
 
     # ルートのmain_summaryに結合する
     root_json["main_summary"].update(main_summary_root_json)

--- a/patients.py
+++ b/patients.py
@@ -228,7 +228,7 @@ def gen_main_summary_data(details_of_confirmed_cases_filename: str):
         case_count_csv = list(csv.DictReader(details_of_confirmed_cases_file))
 
         # 読み込むCSVファイルの行数を指定
-        case_count_list = {str(r["コード"]): int(r["人数"]) for r in case_count_csv[:6]}
+        case_count_list = {str(r["コード"]): int(r["人数"]) for r in case_count_csv[:7]}
 
         return {
             "陽性患者数": (


### PR DESCRIPTION
注意: こちらのPRは静岡県のオープンデータが下記の更新予定の内容に変更された後にマージ（もしくは修正）します

<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #43

## 📝 関連する issue / Related Issues
- 対策サイトissue -> aktnk/covid19#70

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- オープンデータ変更の想定を元に、自宅待機、入院等調整中の項目を増やす

## このPRでの生成結果

### CSVファイル

```
コード,人数
0,124
1,2
2,46
3,178
4,20
5,84
6,4256





＜コード説明＞,
0,入院中
1,うち重症
2,宿泊療養
3,自宅療養
4,入院等調整中
5,死亡
6,退院
```

### json生成結果

```
{
    "main_summary": {
        "attr": "検査実施人数",
        "value": 0,
        "children": [
            {
                "attr": "陽性患者数",
                "value": 4708,
                "children": [
                    {
                        "attr": "入院中",
                        "value": 124,
                        "children": [
                            {
                                "attr": "軽症・中等症",
                                "value": 122
                            },
                            {
                                "attr": "重症",
                                "value": 2
                            }
                        ]
                    },
                    {
                        "attr": "宿泊療養",
                        "value": 46
                    },
                    {
                        "attr": "自宅療養",
                        "value": 178
                    },
                    {
                        "attr": "入院等調整中",
                        "value": 20
                    },
                    {
                        "attr": "死亡",
                        "value": 84
                    },
                    {
                        "attr": "退院",
                        "value": 4256
                    }
                ]
            }
        ]
    }
}
```

## 📸 スクリーンショット / Screenshots
<!-- 参考画像があれば添付してください -->

こちらのPRでのdata.json読み込み結果

https://github.com/hiroyuki-ichikawa/covid19/pull/151

![image](https://user-images.githubusercontent.com/23502/108063310-5b124600-709e-11eb-9034-e9e1404bfeb0.png)
