### PR TITLE
hotfix: change fuji news opendata url

### DIFF
--- a/gen_newsjson.py
+++ b/gen_newsjson.py
@@ -110,9 +110,13 @@ def get_fujicity_newslist() -> list:
     富士市の新型コロナ対策サイトに使う新着情報を富士市のオープンデータから取得してnews.jsonに使うデータを作成します
     結果は"date", "url", "text" の三つのkeyが入る辞書オブジェクトのリストが作成されます。
     取得に失敗した場合は標準エラーとして終了します。
+
+    オープンデータのURL:https://opendata.pref.shizuoka.jp/dataset/8484.html
     """
 
-    TARGET_URL = "https://opendata.pref.shizuoka.jp/dataset/8484/resource/50885/%E5%AF%8C%E5%A3%AB%E5%B8%82%E6%96%B0%E5%9E%8B%E3%82%B3%E3%83%AD%E3%83%8A%E3%82%A6%E3%82%A4%E3%83%AB%E3%82%B9%E9%96%A2%E9%80%A3%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%B9.csv"
+    TARGET_URL = (
+        "https://opendata.pref.shizuoka.jp/fs/5/6/6/5/5/_/__________________.csv"
+    )
     req = requests.get(TARGET_URL)
     # requestのencodingがDLするファイルと合わないので、
     req.encoding = req.apparent_encoding


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- hotfix対応です

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 富士市のニュースを取り扱うオープンデータCSVファイルのアドレスが404となったので変更しました
  - 今まではWEBAPIから見れる`result>resources>download_url` から取得していました
  - 今後は`result>resources>url` より取得します
  - WEB APIのアドレス（jsonの文字列が返ってきます）: https://opendata.pref.shizuoka.jp/api/package_show?id=12698a7b-0af4-446e-926e-697045a819b7

## 📸 スクリーンショット / Screenshots
<!-- 参考画像があれば添付してください -->

curlを使って取得結果の比較をしました。同一の結果だったので、変更後URLを採用しています。

（文字化けしているのはCSVファイルがshift-jisなのが原因です）

変更前URL（PR前までに利用していたアドレスとは違うがURL構造が同じ）

![image](https://user-images.githubusercontent.com/23502/120398633-94cd3b00-c375-11eb-80a5-84f28eb6b2f3.png)

変更後URL

![image](https://user-images.githubusercontent.com/23502/120398715-b29aa000-c375-11eb-82f8-904d3ca5f6be.png)

