### PR TITLE
change url resolve: fujicity news openapi

### DIFF
--- a/gen_newsjson.py
+++ b/gen_newsjson.py
@@ -132,11 +132,6 @@ def get_fujicity_newslist() -> list:
     # requestのencodingがDLするファイルと合わないので修正
     data_req.encoding = data_req.apparent_encoding
 
-    if not data_req.status_code == 200:
-        # TODO:2021-03-19 ここのprintは例外として処理する。NotConnectError的な例外名
-        print("サイトへのアクセスが出来ませんでした: status_code:{}".format(data_req.status_code))
-        sys.exit(1)
-
     news_list = []
     # 富士市のオープンデータには列ヘッダがないので、あらかじめ指定する
     with io.StringIO(data_req.text) as csvfile:


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #60

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- 富士市のニュース記事オープンデータ取得方法を変更しました
- ダウンロードするためのURLが更新事に変更されてしまうので、ふじのくにデータカタログのWeb API経由で取得するようにしました。
