### PR TITLE
patients.csvの無効となる行の除去処理の改善

### DIFF
--- a/patients.py
+++ b/patients.py
@@ -200,9 +200,7 @@ def parse_patients(filename):
         patients_raw_text_lines = list(patients_file)
         clean_lines = []
         for line in patients_raw_text_lines:
-            # テキストファイルとして開くと",,,,,"のようなカンマが多数挿入される行が頻繁に発生している
-            # カンマのみしかない行を除去して残りのデータがある行のみを読み込む
-            # テキスト行からカンマ, 改行コードを取り除いて空の文字列になる場合は無視する
+            # テキストファイルとして開くと",,,,,\n"のようなカンマが多数挿入される行が頻繁に発生するため取り除く
             if "" == line.strip().replace(",", ""):
                 continue
             clean_lines.append(line)


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #63

## 📝 関連する issue / Related Issues
- #53
- #59 

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->

- #53 -> #59 で終端にカンマのみの行が入るデータの際にその行を除去していた
- 現状は#59 での対応
    - 行の中に何も入らないのに入ったような行（空行）の発生に対処をした修正
    - #59 ではCSVファイルの中にあるカンマのみが入ってしまう行を取り除く処理を追加した
    - #59 での修正は問題があるので別のアプローチに切り替える
- #59 の問題点: カンマの数に問題があり、例外的なカンマの数しか考慮していなかった
    - カンマの数が少ない場合: csv.DictReaderで取り込むと、カンマが少ない分だけ値がNoneが入った値が入る（重複除去すると`{"",None}`が入る
    - カンマの数が多い場合: 多い分はListとなってsetできなくなる。エラーで落ちるのでsetできない要素を除外する
    - （どちらもPythonの仕様らしいです。-> https://docs.python.org/ja/3/library/csv.html#csv.DictReader のrestvalとrestkeyを参照
    - カンマの数が列ヘッダと同等: setした後は値はから文字列だけ（重複除去すると`{""}`） <= 今回はこちらで問題が起こる
- このPRのアプローチ
    - カンマの数がどれだけあっても取り除けるようにする
      - 具体的な実装は、CSVファイルとして取り込む前（テキストファイルとしてみた状態で）改行コード, カンマを 削って何も残らない=カンマのみの行になってる場合はその行は取り除く処理にした
- 新しいアプローチの問題点: カンマのみを削った場合に残る値が想定した列分あるのかはみていない
    - 何かしら残る=データがあると判断するが、CSVファイルとして体裁が整ってるものを前提にしている
    - データとして正しい状態かをチェックするような機能はこの先必要かもしれない。列の中身までみて仕様通りかを見る
      オープンデータとしての形式が正しいかをバリデーションを入れた方が安全
    （その際は今のCSVモジュールでの処理よりはpandasを使って前処理させた方が良さそう）

---

## 問題点の検証

### pythonコード

```python
import csv
from io import StringIO

def main():
    # #53の例: カンマの数が列ヘッダより少ない
    example_csv_str_1_1 = """No,例目,全国地方公共団体コード,都道府県名,市区町村名,公表_年月日,発症_年月日,患者_居住地,患者_年代,患者_性別,患者_職業,患者_状態,患者_症状,患者_渡航歴の有無フラグ,患者_退院済フラグ,備考,
1,1,220001,静岡県,1,2020/2/28,,静岡市,60代,男性,,軽症・中等症,軽い咳、のどの違和感,1,1,ダイヤモンドプリンセス号乗客,
,,,,,,,,,,,,,,
,,,,,"""

    example_csv_1_1 = list(csv.DictReader(StringIO(example_csv_str_1_1)))
    print("\n#53の例: カンマの数が列ヘッダより少ない")
    print("csv_raw:\n{}".format(example_csv_str_1_1))
    print("カンマの数")
    print([len([j for j in i.split(",") ]) for i in example_csv_str_1_1.split("\n")][-2:])

    print("#53 をCSVモジュールで取り込んだ結果")
    print(example_csv_1_1[-1])
    print(example_csv_1_1[-2])
    print("set（重複除去）した結果")
    print(set(example_csv_1_1[-1].values()))
    print(set(example_csv_1_1[-2].values()))

    # #53の例: カンマの数が列ヘッダより多い
    example_csv_str_1_2 = """No,例目,全国地方公共団体コード,都道府県名,市区町村名,公表_年月日,発症_年月日,患者_居住地,患者_年代,患者_性別,患者_職業,患者_状態,患者_症状,患者_渡航歴の有無フラグ,患者_退院済フラグ,備考,
1,1,220001,静岡県,1,2020/2/28,,静岡市,60代,男性,,軽症・中等症,軽い咳、のどの違和感,1,1,ダイヤモンドプリンセス号乗客,
,,,,,,,,,,,,,,,,,,,,,,,,,,,,"""

    example_csv_1_2 = list(csv.DictReader(StringIO(example_csv_str_1_2)))
    print("#53の例: カンマの数が列ヘッダより多い")
    print("\ncsv_raw:\n{}".format(example_csv_str_1_2))
    print("カンマの数")
    print([len([j for j in i.split(",") ]) for i in example_csv_str_1_2.split("\n")][-1:])

    print("#53 をCSVモジュールで取り込んだ結果")
    print(example_csv_1_2[-1])
    print("set（重複除去）できないので回避処理を入れる")

    # set（重複除去）はlistはできないのでエラーが起こるので、キーがNoneとなるものを消す
    # print(set(example_csv_1_2[-1].values()))
    example_csv_1_2_mod = []
    for row in example_csv_1_2:
        if None in row.keys():
            row.pop(None)
        example_csv_1_2_mod.append(row)
    print(set(example_csv_1_2_mod[-1].values()))

    # #63の例: カンマが列ヘッダと同じだけの数がある
    example_csv_str_2 = """No,例目,全国地方公共団体コード,都道府県名,市区町村名,公表_年月日,発症_年月日,患者_居住地,患者_年代,患者_性別,患者_職業,患者_状態,患者_症状,患者_渡航歴の有無フラグ,患者_退院済フラグ,備考,
1,1,220001,静岡県,1,2020/2/28,,静岡市,60代,男性,,軽症・中等症,軽い咳、のどの違和感,1,1,ダイヤモンドプリンセス号乗客,
,,,,,,,,,,,,,,,,"""

    example_csv_2 = list(csv.DictReader(StringIO(example_csv_str_2)))
    print("#63の例: カンマが列ヘッダと同じだけの数がある")
    print("\ncsv_raw:\n{}".format(example_csv_str_1_2))
    print("カンマの数")
    print([len([j for j in i.split(",")]) for i in example_csv_str_2.split("\n")][-1:])
    print("#63 をCSVモジュールで取り込んだ結果")
    print(example_csv_2[-1])
    print("set（重複除去）した結果")
    print(set(example_csv_2[-1].values()))

if __name__ == "__main__":
    main()
```

### 実行結果

```bash

#53の例: カンマの数が列ヘッダより少ない
csv_raw:
No,例目,全国地方公共団体コード,都道府県名,市区町村名,公表_年月日,発症_年月日,患者_居住地,患者_年代,患者_性別,患者_職業,患者_状態,患者_症状,患者_渡航歴の有無フラグ,患者_退院済フラグ,備考,
1,1,220001,静岡県,1,2020/2/28,,静岡市,60代,男性,,軽症・中等症,軽い咳、のどの違和感,1,1,ダイヤモンドプリンセス号乗客,
,,,,,,,,,,,,,,
,,,,,
カンマの数
[15, 6]
#53 をCSVモジュールで取り込んだ結果
{'No': '', '例目': '', '全国地方公共団体コード': '', '都道府県名': '', '市区町村名': '', '公表_年月日': '', '発症_年月日': None, '患者_居住地': None, '患者_年代': None, '患者_性別': None, '患者_職業': None, '患者_状態': None, '患者_症状': None, '患者_渡航歴の有無フラグ': None, '患者_退院済フラグ': None, '備考': None, '': None}
{'No': '', '例目': '', '全国地方公共団体コード': '', '都道府県名': '', '市区町村名': '', '公表_年月日': '', '発症_年月日': '', '患者_居住地': '', '患者_年代': '', '患者_性別': '', '患者_職業': '', '患者_状態': '', '患者_症状': '', '患者_渡航歴の有無フラグ': '', '患者_退院済フラグ': '', '備考': None, '': None}
set（重複除去）した結果
{'', None}
{'', None}

#53の例: カンマの数が列ヘッダより多い
csv_raw:
No,例目,全国地方公共団体コード,都道府県名,市区町村名,公表_年月日,発症_年月日,患者_居住地,患者_年代,患者_性別,患者_職業,患者_状態,患者_症状,患者_渡航歴の有無フラグ,患者_退院済フラグ,備考,
1,1,220001,静岡県,1,2020/2/28,,静岡市,60代,男性,,軽症・中等症,軽い咳、のどの違和感,1,1,ダイヤモンドプリンセス号乗客,
,,,,,,,,,,,,,,,,,,,,,,,,,,,,
カンマの数
[29]
#53 をCSVモジュールで取り込んだ結果
{'No': '', '例目': '', '全国地方公共団体コード': '', '都道府県名': '', '市区町村名': '', '公表_年月日': '', '発症_年月日': '', '患者_居住地': '', '患者_年代': '', '患者_性別': '', '患者_職業': '', '患者_状態': '', '患者_症状': '', '患者_渡航歴の有無フラグ': '', '患者_退院済フラグ': '', '備考': '', '': '', None: ['', '', '', '', '', '', '', '', '', '', '', '']}
set（重複除去）できないので回避処理を入れる
{''}

#63の例: カンマが列ヘッダと同じだけの数がある
csv_raw:
No,例目,全国地方公共団体コード,都道府県名,市区町村名,公表_年月日,発症_年月日,患者_居住地,患者_年代,患者_性別,患者_職業,患者_状態,患者_症状,患者_渡航歴の有無フラグ,患者_退院済フラグ,備考,
1,1,220001,静岡県,1,2020/2/28,,静岡市,60代,男性,,軽症・中等症,軽い咳、のどの違和感,1,1,ダイヤモンドプリンセス号乗客,
,,,,,,,,,,,,,,,,,,,,,,,,,,,,
カンマの数
[17]
#63 をCSVモジュールで取り込んだ結果
{'No': '', '例目': '', '全国地方公共団体コード': '', '都道府県名': '', '市区町村名': '', '公表_年月日': '', '発症_年月日': '', '患者_居住地': '', '患者_年代': '', '患者_性別': '', '患者_職業': '', '患者_状態': '', '患者_症状': '', '患者_渡航歴の有無フラグ': '', '患者_退院済フラグ': '', '備考': '', '': ''}
set（重複除去）した結果
{''}

```