### PR TITLE
href属性の取得方法、使用前の空チェックを追加

### DIFF
--- a/gen_newsjson.py
+++ b/gen_newsjson.py
@@ -81,7 +81,13 @@ def get_shizuoka_newslist() -> list:
         news_a_tag = news_p_tag.find_next()
 
         # urlの正規化:絶対アドレスではない場合の処理
-        news_link = news_a_tag["href"]
+
+        # https://github.com/aktnk/covid19/issues/123 の対策
+        news_link = news_a_tag.get("href")
+        if news_link is None:
+            print(f"'{news_p_tag}'にhrefがないためスキップします")
+            continue
+
         if "http" not in news_link:
             news_link = "https://www.pref.shizuoka.jp" + news_a_tag["href"]
 


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #68
- close https://github.com/aktnk/covid19/issues/123

## 📝 関連する issue / Related Issues
- なし

## ⛏ 変更内容 / Details of Changes
<!-- 変更を端的に箇条書きで -->
<!-- List down your changes concisely -->
- href属性の取得方法を変更
- href属性値を使う前に有無を確認し、無ければ次のpタグの処理へ移る

## 📸 スクリーンショット / Screenshots
<!-- 参考画像があれば添付してください -->
静岡県と富士市のnews.json生成動作
![image](https://user-images.githubusercontent.com/13390370/189388801-0fa16e39-63d5-4587-a2d5-e3921d0d00fc.png)
→href属性が無い場合、メッセージを表示します。

県のnews.json生成結果
![image](https://user-images.githubusercontent.com/13390370/189389108-86589582-a74c-4c45-b5dc-f15b819df2e0.png)
→正常に生成されました。

富士市のnews.json生成結果
![image](https://user-images.githubusercontent.com/13390370/189389245-546091c8-9f40-401b-9eb7-847b51baf401.png)
→正常に生成されました。
